### PR TITLE
DevOps: Indicate artifact full path

### DIFF
--- a/.github/workflows/deploy-to-appengine.yaml
+++ b/.github/workflows/deploy-to-appengine.yaml
@@ -43,6 +43,7 @@ jobs:
         uses: 'actions/download-artifact@v2'
         with:
           name: 'openapi-spec'
+          path: '${{ github.workspace }}/api'
       - name: 'Authenticate'
         uses: 'google-github-actions/auth@v0'
         with:


### PR DESCRIPTION
It seemed that the downloaded artifact was not placed in the correct directory, so maybe forcing it to the directory will fix the issue